### PR TITLE
fix: too many clients issue fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ WS_137=wss://polygon-mainnet.g.alchemy.com/v2/ALCHEMY_KEY
 ADMIN_API_KEY=MY_KEY
 
 # Postgres and Redis connection URLs
+DATABASE_POOL_SIZE=60
 DATABASE_URL=postgresql://postgres:password@127.0.0.1:5432/postgres?schema=public
 REDIS_URL=redis://redis:password@127.0.0.1:6379
 BACKEND_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres?schema=public

--- a/src/common/db.ts
+++ b/src/common/db.ts
@@ -25,7 +25,7 @@ export const edb1 = pgp({
 export const idb = pgp({
   connectionString: config.databaseUrl,
   keepAlive: true,
-  max: 60,
+  max: config.databasePoolSize,
   connectionTimeoutMillis: 30 * 1000,
   query_timeout: 5 * 60 * 1000,
   statement_timeout: 5 * 60 * 1000,
@@ -49,7 +49,7 @@ export const hdb = pgp({
 export const redb = pgp({
   connectionString: config.readReplicaDatabaseUrl,
   keepAlive: true,
-  max: 60,
+  max: config.databasePoolSize,
   connectionTimeoutMillis: 10 * 1000,
   query_timeout: 10 * 1000,
   statement_timeout: 10 * 1000,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,6 +36,7 @@ export const config = {
 
   disableRealtimeMetadataRefresh: Boolean(Number(process.env.DISABLE_REALTIME_METADATA_REFRESH)),
 
+  databasePoolSize: Number(process.env.DATABASE_POOL_SIZE || 100),
   databaseUrl: String(process.env.DATABASE_URL),
   databaseSSL: Boolean(Number(process.env.DATABASE_SSL)),
   readReplicaDatabaseUrl: String(process.env.READ_REPLICA_DATABASE_URL || process.env.DATABASE_URL),

--- a/src/jobs/wallets/fetch-history-queue.ts
+++ b/src/jobs/wallets/fetch-history-queue.ts
@@ -2,11 +2,10 @@ import { syncRedis } from "@/common/redis";
 import { Job, Queue, QueueScheduler, Worker } from "bullmq";
 import { config } from "@/config/index";
 import { logger } from "@/common/logger";
-import { redb } from "@/common/db";
+import { idb } from "@/common/db";
 import { fromBuffer, toBuffer } from "@/common/utils";
 import { randomUUID } from "crypto";
 import * as walletHistoryQueue from "./wallet-history-queue";
-import { isCachedWallet } from "@/utils/in-memory-cache";
 
 const QUEUE_NAME = "fetch-history-queue";
 const ROW_COUNT = 100;
@@ -32,7 +31,7 @@ if (config.syncPacman) {
         const { address, workspaceId, isWalletCached } = job.data;
         logger.info(QUEUE_NAME, `${JSON.stringify(job.data)} --- ${job.name}`);
         const limit = ROW_COUNT;
-        const { count: totalCount }: { count: number } = await redb.one(
+        const { count: totalCount }: { count: number } = await idb.one(
           `select count(1) from user_transactions ut
               where ut.hash in 
               (select ut2.hash from user_transactions ut2
@@ -47,7 +46,7 @@ if (config.syncPacman) {
         let batch = 1,
           skip = 0;
         while (batch <= totalBatch) {
-          const userActivities: walletHistoryQueue.IRawUserTransaction[] = await redb.manyOrNone(
+          const userActivities: walletHistoryQueue.IRawUserTransaction[] = await idb.manyOrNone(
             `select * from user_transactions ut
               where ut.hash in 
               (select ut2.hash from user_transactions ut2

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -130,7 +130,7 @@ export const syncEvents = async (
             });
           }
         } catch (error) {
-          logger.info("sync-events", `Failed to handle events: ${error}`);
+          logger.error("sync-events", `Failed to handle events: ${error}`);
           throw error;
         }
       }

--- a/src/sync/events/storage/ft-transfer-events.ts
+++ b/src/sync/events/storage/ft-transfer-events.ts
@@ -108,7 +108,6 @@ export const addEvents = async (events: Event[], backfill: boolean, chainId: num
         await idb.none(pgp.helpers.concat(queries));
       }
     }
-    logger.info("ft-events-deadlock", `succedssfull completiom free_chain_id:${chainId}`);
   } catch (err) {
     await wait();
     logger.error(

--- a/src/utils/in-memory-cache.ts
+++ b/src/utils/in-memory-cache.ts
@@ -1,4 +1,4 @@
-import { idb, redb } from "@/common/db";
+import { idb } from "@/common/db";
 import { logger } from "@/common/logger";
 import { isEmpty, isNil } from "lodash";
 
@@ -36,7 +36,7 @@ export const updateWalletCache = async (address: string) => {
 };
 
 export const getTrackedWalletByAddress = async (address: string): Promise<Record<string, boolean>> => {
-  const trackedWallet = await redb.oneOrNone(
+  const trackedWallet = await idb.oneOrNone(
     "select address from tracked_wallets where status = 1 and address = $/address/ ",
     { address },
   );
@@ -49,15 +49,14 @@ export const getCacheWallets = async (): Promise<Record<string, boolean>> => {
 
   if (!isEmpty(wallets)) return wallets;
 
-  const trackedWallets = await redb.manyOrNone(
+  const trackedWallets = await idb.manyOrNone(
     "select address from tracked_wallets where status = 1"
   );
-  logger.info("save-wallet-address", `got this wallets from db ${trackedWallets?.length}`);
   return (
-    trackedWallets.reduce((acc: Record<string, boolean>, { address }) => {
+    (trackedWallets || []).reduce((acc: Record<string, boolean>, { address }) => {
       acc[address] = true;
       return acc;
-    }, {}) ?? {}
+    }, {})
   );
 };
 
@@ -99,7 +98,7 @@ export const isCachedWallet = async (address: string) => {
 
     return true;
   } catch (err) {
-    logger.error('isCachedWallet', (err as Error).message);
+    logger.error("isCachedWallet", (err as Error).message);
     return false;
   }
 };


### PR DESCRIPTION
1. Replaced `redb` with `idb` db instance in `fetch-history-queue` and `in-memory-cache`.
2. Db pool size can now dynamically be set on the basis of env. Parameter: DATABASE_POOL_SIZE;

**NOTE:**
* Default pool size is set to 60 if env param not found in config file.
* On staging database, RDS supports 840 connections, so please set pool size in .env accordingly. @shubhampatwa 