### PR TITLE
feat: webhook registration apis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ WS_137=wss://polygon-mainnet.g.alchemy.com/v2/ALCHEMY_KEY
 
 # Required by all admin APIs (via the `X-Admin-Api-Key` header)
 ADMIN_API_KEY=MY_KEY
+JWT_SECRET=JWT_SECRET
+WEBHOOK_SERVER_KEY=WEBHOOK_SERVER_KEY
 
 # Postgres and Redis connection URLs
 DATABASE_POOL_SIZE=60

--- a/package.json
+++ b/package.json
@@ -67,12 +67,14 @@
     "ethers": "5.6.8",
     "graphql": "^16.3.0",
     "graphql-request": "^4.0.0",
+    "hapi-auth-jwt2": "^10.4.0",
     "hapi-swagger": "14.2.4",
     "husky": "^7.0.4",
     "ioredis": "^4.28.0",
     "jest": "^29.0.3",
     "joi": "17.x",
     "json-stable-stringify": "^1.0.1",
+    "jsonwebtoken": "^9.0.0",
     "module-alias": "^2.2.2",
     "newrelic": "^9.11.0",
     "node-cron": "^3.0.0",
@@ -107,6 +109,7 @@
     "@/events-sync": "dist/sync/events"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.1",
     "tsconfig-paths": "^4.1.0"
   }
 }

--- a/src/api/endpoints/accounts/account.ts
+++ b/src/api/endpoints/accounts/account.ts
@@ -1,0 +1,103 @@
+import { idb } from "@/common/db";
+import { logger } from "@/common/logger";
+import { Request, ResponseToolkit, RouteOptions } from "@hapi/hapi";
+import axios from "axios";
+import Joi from "joi";
+import moment from "moment";
+import jwt from "jsonwebtoken";
+import { config } from "@/config/index";
+
+export interface RegisterAppDto {
+  name: string;
+  email: string;
+  webhookUrl: string;
+  webhookAuthKey: string;
+}
+
+export const registerApp: RouteOptions = {
+  validate: {
+    payload: Joi.object({
+      name: Joi.string().min(3).required(),
+      email: Joi.string().email({ tlds: { allow: false } }).required(),
+      webhookUrl: Joi.string().uri().required(),
+      webhookAuthKey: Joi.string().min(8).required(),
+    })
+  },
+  handler: async (request: Request, h) => {
+    const data = request.payload as RegisterAppDto;
+    
+    try {
+      const isValidWebhook = await validateWebhook(data.webhookUrl, data.webhookAuthKey);
+      if (isValidWebhook) {
+        const account = await idb.oneOrNone(`
+          INSERT INTO accounts (name, email, webhook_url, webhook_auth_key)
+          VALUES('${data.name}', '${data.email}', '${data.webhookUrl}', '${data.webhookAuthKey}')
+          RETURNING id
+        `);
+
+        if (account?.id) {
+          const secretKey = jwt.sign({ id: account.id }, config.jwtSecret, { issuer: "iss:indexer" });
+          await idb.none(`UPDATE accounts SET secret_key = '${secretKey}' WHERE id = ${account.id}`);
+
+          const respData = { id: account.id, name: data.name, secretKey: secretKey };
+          return h.response({ statusCode: 200, data: respData,  message: "Ok" }).code(200);
+        }
+
+        return h.response({ statusCode: 500, message: "Something went wrong." }).code(500);
+      }
+
+      return h.response({ statusCode: 400, message: "Webhook URL is not valid." }).code(400);
+    } catch (error) {
+      logger.error(`register-app`, `Handler failure: ${error}`);
+      throw error;
+    }
+  },
+};
+
+export const updateApp: RouteOptions = {
+  validate: {
+    payload: Joi.object({
+      name: Joi.string().min(3).required(),
+      webhookUrl: Joi.string().uri().required(),
+      webhookAuthKey: Joi.string().min(8).required(),
+    })
+  },
+  handler: async (request: Request, h: ResponseToolkit) => {
+    try {
+      const data = request.payload as RegisterAppDto;
+      const accountId = request.auth.credentials.id;
+
+      const isValidWebhook = await validateWebhook(data.webhookUrl, data.webhookAuthKey);
+      if (isValidWebhook) {
+        await idb.none(`
+          UPDATE accounts SET 
+            name = '${data.name}', 
+            webhook_url = '${data.webhookUrl}', 
+            webhook_auth_key = '${data.webhookAuthKey}'
+          WHERE id = ${accountId}
+        `);
+
+        return h.response({ statusCode: 200, data,  message: "Ok" }).code(200);
+      }
+
+      return h.response({ statusCode: 400, message: "Webhook URL is not valid." }).code(400);
+    } catch (error) {
+      logger.error(`register-app`, `Handler failure: ${error}`);
+      throw error;
+    }
+  },
+};
+
+async function validateWebhook(url: string, authKey: string): Promise<boolean> {
+  try {
+    const payload = {
+      event: "HEALTH_CHECK",
+      timestamp: moment().format("YYYY-MM-DD HH:MM:SS"),
+      data: null
+    }
+    const resp = await axios.post(url, payload, { headers: {"Authorization" : `Bearer ${authKey}` } } );
+    return resp.status === 200;
+  } catch (err) {
+    return false;
+  }
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,4 +1,5 @@
 import * as userTransfersActivityEndpoints from "@/api/endpoints/user-activity/transfers";
+import * as accounts from "@/api/endpoints/accounts/account";
 import { getHistory } from "@/api/endpoints/balance/history";
 import { Server } from "@hapi/hapi";
 import { getHistoryDetails } from "./endpoints/balance/historyDetail";
@@ -6,6 +7,18 @@ import { getBalance } from "./endpoints/balance/totalbalance";
 import { getAssetsDetails } from "./endpoints/balance/assetDetail";
 
 export const setupRoutes = (server: Server) => {
+  server.route({
+    method: "POST",
+    path: "/register-app",
+    options: { auth: "webhook_server", ...accounts.registerApp },
+  });
+
+  server.route({
+    method: "POST",
+    path: "/update-app",
+    options: { auth: "webhook_client_auth", ...accounts.updateApp },
+  });
+
   server.route({
     method: "GET",
     path: "/user-transfer-activities",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,8 @@ export const config = {
   ws137: String(process.env.RPC_137),
 
   adminApiKey: String(process.env.ADMIN_API_KEY),
+  jwtSecret: String(process.env.JWT_SECRET),
+  webhookServerKey: String(process.env.WEBHOOK_SERVER_KEY),
   bullmqAdminPassword: String(process.env.BULLMQ_ADMIN_PASSWORD),
   arweaveRelayerKey: process.env.ARWEAVE_RELAYER_KEY
     ? String(process.env.ARWEAVE_RELAYER_KEY)

--- a/src/migrations/1681988667172_accounts.sql
+++ b/src/migrations/1681988667172_accounts.sql
@@ -1,0 +1,19 @@
+-- Up Migration
+
+CREATE TABLE "accounts" (
+  "id" SERIAL PRIMARY KEY,
+  "name" VARCHAR NOT NULL,
+  "email" VARCHAR NOT NULL,
+  "secret_key" VARCHAR NULL,
+  "webhook_url" VARCHAR NOT NULL,
+  "webhook_auth_key" VARCHAR NOT NULL,
+  "active" BOOLEAN NOT NULL DEFAULT true,
+  "created_at" timestamp with time zone DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX unique_email
+ON accounts(email);
+
+-- Down Migration
+
+DROP TABLE "accounts";


### PR DESCRIPTION
PR contains:
1. register webhook app api
2. update webhook api
3. two additional keys in .env: `JWT_SECRET`, `WEBHOOK_SERVER_KEY`


NOTE: 
* Basic auth using WEBHOOK_SERVER_KEY as password is implemented for Register Api.
* JWT_SECRET is being used to generate account secret keys.


---
**Register API Curl Example**
```js
curl --location 'http://localhost:3000/register-app' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic d2ViaG9vazpqZGVkZzM3ZDM4ZDg=' \
--data-raw '{
    "name": "Pacman",
    "email": "gulfam1@priori.capital",
    "webhookUrl": "http://localhost:3000/health-check",
    "webhookAuthKey": "authkey12"
}'


/** 
* Here username is `webhook` and password is WEBHOOK_SERVER_KEY in .env. 
* For Basic Auth, generate string after concatenating username and password 
* separated by colon symbol and base64 encoded.
**/
btoa('webhook:jdedg37d38d8') => 'd2ViaG9vazpqZGVkZzM3ZDM4ZDg=';
```